### PR TITLE
Add default constructor to NotImplementedException

### DIFF
--- a/src/main/java/org/lucian/todos/exceptions/NotImplementedException.java
+++ b/src/main/java/org/lucian/todos/exceptions/NotImplementedException.java
@@ -12,5 +12,12 @@ public class NotImplementedException extends RuntimeException {
         super(message != null && !message.isEmpty() ? message : "This feature is not implemented yet.");
         
     }
+
+    /**
+     * Constructs a new NotImplementedException with no detail message.
+     */
+    public NotImplementedException() {
+        super("This feature is not implemented yet.");
+    }
     
 }

--- a/src/main/java/org/lucian/todos/exceptions/NotImplementedException.java
+++ b/src/main/java/org/lucian/todos/exceptions/NotImplementedException.java
@@ -1,6 +1,7 @@
 package org.lucian.todos.exceptions;
 
 public class NotImplementedException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "This feature is not implemented yet.";
 
     /**
      * Constructs a new NotImplementedException with the specified detail message.
@@ -8,16 +9,13 @@ public class NotImplementedException extends RuntimeException {
      * @param message the detail message
      */
     public NotImplementedException(String message) {
-        
-        super(message != null && !message.isEmpty() ? message : "This feature is not implemented yet.");
-        
+        super(message != null && !message.isEmpty() ? message : DEFAULT_MESSAGE);
     }
 
     /**
      * Constructs a new NotImplementedException with no detail message.
      */
     public NotImplementedException() {
-        super("This feature is not implemented yet.");
+        super(DEFAULT_MESSAGE);
     }
-    
 }


### PR DESCRIPTION
This pull request adds a new constructor to the `NotImplementedException` class to provide a default message when no detail message is specified.

* [`src/main/java/org/lucian/todos/exceptions/NotImplementedException.java`](diffhunk://#diff-67ace4cf6aec1fc9656cece99de99f19522880297023b4b1e27a50e4e0dc52e8R16-R22): Added a no-argument constructor to the `NotImplementedException` class that initializes the exception with a default message: "This feature is not implemented yet."